### PR TITLE
Create anyway

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ tileReduce({
         console.log('Features total: %d', uniqueIDs.length);
     }
     if (geojson) {
-        gsm(tmpGeojson, geojson);
-        fs.unlinkSync(tmpGeojson);
-        fs.rmdirSync(tmpDir);
+        gsm(tmpGeojson, geojson, function() {
+            fs.closeSync(tmpFd);
+            fs.unlinkSync(tmpGeojson);
+            fs.rmdirSync(tmpDir);
+        });
     }
 });

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ var count = cleanArguments.argv.count,
     mbtilesPath = cleanArguments.argv.mbtiles,
     tmpGeojson = cleanArguments.tmpGeojson,
     tagFilter = cleanArguments.argv.filter;
+
+
 var OSMID = [];
 
 if ((!geojson && !count) || !mbtilesPath || argv.help) {
@@ -35,6 +37,11 @@ tileReduce({
         'dates': dates,
         'users': users,
         'tagFilter': tagFilter
+    }
+})
+.on('start', function () {
+    if (tmpGeojson) {
+        fs.openSync(tmpGeojson,'w');
     }
 })
 .on('reduce', function (id) {

--- a/index.js
+++ b/index.js
@@ -18,10 +18,9 @@ var count = cleanArguments.argv.count,
     dates = cleanArguments.argv.dates,
     mbtilesPath = cleanArguments.argv.mbtiles,
     tmpGeojson = cleanArguments.tmpGeojson,
-    tagFilter = cleanArguments.argv.filter;
-
-
-var OSMID = [];
+    tagFilter = cleanArguments.argv.filter,
+    osmID = [],
+    tmpFd;
 
 if ((!geojson && !count) || !mbtilesPath || argv.help) {
     help();
@@ -41,17 +40,17 @@ tileReduce({
 })
 .on('start', function () {
     if (tmpGeojson) {
-        fs.openSync(tmpGeojson,'w');
+        tmpFd = fs.openSync(tmpGeojson,'w');
     }
 })
 .on('reduce', function (id) {
     if (count) {
-        OSMID = OSMID.concat(id);
+        osmID = osmID.concat(id);
     }
 })
 .on('end', function () {
     if (count) {
-        var uniqueIDs = _.uniq(OSMID);
+        var uniqueIDs = _.uniq(osmID);
         console.log('Features total: %d', uniqueIDs.length);
     }
     if (geojson) {

--- a/map.js
+++ b/map.js
@@ -29,7 +29,6 @@ module.exports = function (data, tile, writeData, done) {
         fs.appendFileSync(mapOptions.tmpGeojson, JSON.stringify(fc) + '\n');
     }
     done(null, osmID);
-//    done(null, fs.existsSync(mapOptions.tmpGeojson));
 };
 
 function parseDates(dates) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "feature-filter": "2.1.0",
     "fs": "0.0.2",
-    "geojson-stream-merge": "^1.0.0",
+    "geojson-stream-merge": "https://github.com/geohacker/geojson-stream-merge/tarball/e80e16f49494f3bfcb723f55d1cf510c163db632",
     "minimist": "^1.2.0",
     "path": "^0.12.7",
     "tile-reduce": "^3.1.1",


### PR DESCRIPTION
* Create a tempGeojson before running `tile-reduce` so that an output file is created anyway, but contains no features.
* Use a new version of `geojson-stream-merge` which returns a callback.